### PR TITLE
Matlab versions after R2015b

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,19 +9,30 @@ recursive-include cis_interface *.sh
 recursive-include cis_interface *.m
 recursive-include cis_interface *.h
 recursive-include cis_interface *.hpp
+recursive-include cis_interface *.lpy
+recursive-include cis_interface *.obj
 include cis_interface/tests/data/*.txt
 include cis_interface/tests/yaml/*.yml
 include cis_interface/tests/scripts/*.m
+include cis_interface/tests/scripts/*.h
 include cis_interface/tests/scripts/*.c
 include cis_interface/tests/scripts/*.cpp
 include cis_interface/tests/scripts/*.py
+include cis_interface/tests/scripts/*.lpy
+include cis_interface/tests/scripts/CMakeLists.txt
+include cis_interface/tests/scripts/Makefile_linux
+include cis_interface/tests/scripts/Makefile_windows
 include cis_interface/examples/*.sh
 include cis_interface/examples/*.yml
 include cis_interface/examples/*/src/*.m
+include cis_interface/examples/*/src/*.h
 include cis_interface/examples/*/src/*.c
 include cis_interface/examples/*/src/*.cpp
 include cis_interface/examples/*/src/*.py
+include cis_interface/examples/*/src/*.lpy
 include cis_interface/examples/*/Input/*.txt
+include cis_interface/examples/*/Input/*.ply
+include cis_interface/examples/*/Input/*.obj
 graft docs
 include versioneer.py
 include cis_interface/_version.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,37 +2,25 @@ include *.md
 include *.png
 include *.svg
 include *.txt
-include cis_interface/drivers/matlab_screenrc
 recursive-include cis_interface *.cfg
 recursive-include cis_interface *.yml
 recursive-include cis_interface *.sh
 recursive-include cis_interface *.m
+recursive-include cis_interface *.c
 recursive-include cis_interface *.h
+recursive-include cis_interface *.cpp
 recursive-include cis_interface *.hpp
 recursive-include cis_interface *.lpy
+recursive-include cis_interface *.ply
 recursive-include cis_interface *.obj
-include cis_interface/tests/data/*.txt
-include cis_interface/tests/yaml/*.yml
-include cis_interface/tests/scripts/*.m
-include cis_interface/tests/scripts/*.h
-include cis_interface/tests/scripts/*.c
-include cis_interface/tests/scripts/*.cpp
-include cis_interface/tests/scripts/*.py
-include cis_interface/tests/scripts/*.lpy
+recursive-include cis_interface *.txt
+recursive-include cis_interface/examples *.py
+recursive-include cis_interface/tests/scripts *.py
+include cis_interface/drivers/matlab_screenrc
+include cis_interface/regex/CMakeLists.txt
 include cis_interface/tests/scripts/CMakeLists.txt
 include cis_interface/tests/scripts/Makefile_linux
 include cis_interface/tests/scripts/Makefile_windows
-include cis_interface/examples/*.sh
-include cis_interface/examples/*.yml
-include cis_interface/examples/*/src/*.m
-include cis_interface/examples/*/src/*.h
-include cis_interface/examples/*/src/*.c
-include cis_interface/examples/*/src/*.cpp
-include cis_interface/examples/*/src/*.py
-include cis_interface/examples/*/src/*.lpy
-include cis_interface/examples/*/Input/*.txt
-include cis_interface/examples/*/Input/*.ply
-include cis_interface/examples/*/Input/*.obj
 graft docs
 include versioneer.py
 include cis_interface/_version.py

--- a/cis_interface/drivers/MatlabModelDriver.py
+++ b/cis_interface/drivers/MatlabModelDriver.py
@@ -118,7 +118,10 @@ def stop_matlab(screen_session, matlab_engine, matlab_session):  # pragma: matla
                 matlab.engine._engines.remove(x)
         # Either exit the engine or remove its reference
         if matlab_session in matlab.engine.find_matlab():
-            matlab_engine.eval('exit', nargout=0)
+            try:
+                matlab_engine.eval('exit', nargout=0)
+            except matlab.engine.EngineError:
+                pass
         else:  # pragma: no cover
             matlab_engine.__dict__.pop('_matlab')
     # Stop the screen session containing the Matlab shared session
@@ -398,11 +401,9 @@ class MatlabModelDriver(ModelDriver):  # pragma: matlab
             try:
                 self.model_process.future.result()
                 self.model_process.print_output()
-            except matlab.engine.EngineError as e:
+            except matlab.engine.EngineError:
                 self.model_process.print_output()
-                # self.model_process.on_matlab_error()
-                # self.exception("EngineError while running Matlab model.")
-            except BaseException as e:
+            except BaseException:
                 self.model_process.print_output()
                 self.exception("Error running model.")
         else:


### PR DESCRIPTION
These changes are to address issue #26, allowing support for running Matlab models with Matlab versions above R2015b.