### PR TITLE
added support for retrieving YAML files from remote GIT repositories

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -4,13 +4,13 @@ Getting started
 ===============
 
 
-The |yggdrasil| framework runs user defined models and orchestrates asynchronous 
-communication between models using drivers that coordinate the different 
-components via threads. Model drivers run the models as seperate processes 
-and monitor them to redirect output to stdout and determine if the model 
-is still running, needs to be terminated, or has encountered an error. 
-Input/output drivers connect communication channels (comms) between models 
-and/or files. On the model side, interface API functions/classes are provided 
+The |yggdrasil| framework runs user defined models and orchestrates asynchronous
+communication between models using drivers that coordinate the different
+components via threads. Model drivers run the models as seperate processes
+and monitor them to redirect output to stdout and determine if the model
+is still running, needs to be terminated, or has encountered an error.
+Input/output drivers connect communication channels (comms) between models
+and/or files. On the model side, interface API functions/classes are provided
 in different programming languages to allow models to access these comms.
 
 
@@ -35,7 +35,7 @@ the path to the model source code that should be run. There are specialized
 drivers for simple source written in Python, Matlab, C, and C++, but any
 executable can be run as a model using ``language: executable`` and passing the
 path to the executable to the ``args`` parameter. Additional information on
-the format |yggdrasil| YAML files should take can be found in the 
+the format |yggdrasil| YAML files should take can be found in the
 :ref:`YAML Files <yaml_rst>` section.
 
 This model can then be run using the |yggdrasil| framework by calling the
@@ -55,7 +55,24 @@ or including multiple models in a single YAML file.
 
 .. include:: examples/gs_lesson2_yml.rst
 
-	     
+
+Running remote models
+---------------------
+
+Models stored on remote Git repositories can be run by prepending 'git:' to the YAML file::
+
+  $ yggrun git:http://github.com/foo/bar/yam/remote_model.yml
+
+`yggrun` will clone the repo (foo/bar in this example) and then process remote_model.yml as normal. The
+host site need not be specified if it is github.com::
+
+  $ yggrun git:foo/bar/yam/remote_model.yml
+
+will behave identically to the first example. Remote and local models can be mixed on
+the command line::
+
+  $ yggrun model1.yml git:foo/bar/yam/remote_model.yml model2.yml
+
 Model file input/output
 -----------------------
 
@@ -67,20 +84,20 @@ named ``input`` and sends output to a channel named ``output``.
 .. include:: examples/gs_lesson3_src.rst
 
 .. note::
-   Real models YAMLs should use more description names for the input and output 
-   channels to make it easier for collaborators to determine the information 
+   Real models YAMLs should use more description names for the input and output
+   channels to make it easier for collaborators to determine the information
    begin passed through the channel.
 
 In the YAML used to run this model, those channels are declared in the model
-definition and then linked to files by entries in the ``connections`` section 
+definition and then linked to files by entries in the ``connections`` section
 of the YAML.
 
 .. include:: examples/gs_lesson3_yml.rst
 
-The ``input_file`` and ``output_file`` connection fields can either be 
-the path to the file (either absolute or relative to the directory 
-containing the YAML file) or a mapping with fields descripting the 
-file. In particular, the ``filetype`` keyword specifies the format of 
+The ``input_file`` and ``output_file`` connection fields can either be
+the path to the file (either absolute or relative to the directory
+containing the YAML file) or a mapping with fields descripting the
+file. In particular, the ``filetype`` keyword specifies the format of
 the file being read/written. Supported values include:
 
 ===========    =================================================================
@@ -93,33 +110,33 @@ table          The file is an ASCII table that will be read/written one row
                will be read/written all at once.
 pandas         The file is a Pandas frame output as a table.
 pickle         The file contains one or more pickled Python objects.
-ply            The file is in `Ply <http://paulbourke.net/dataformats/ply/>`_ 
+ply            The file is in `Ply <http://paulbourke.net/dataformats/ply/>`_
                data format for 3D structures.
-obj            The file is in `Obj <http://paulbourke.net/dataformats/obj/>`_ 
+obj            The file is in `Obj <http://paulbourke.net/dataformats/obj/>`_
                data format for 3D structures.
 ===========    =================================================================
 
 
-The above example shows the basic case of receiving raw messages from a channel, 
-but there are also interface functions which can process these raw messages to 
-extract variables and fields for the model ``inputs`` and ``outputs`` to 
-specify how that should be done. For examples of how to use formatted messages 
-with the above file types and input/output options, see 
+The above example shows the basic case of receiving raw messages from a channel,
+but there are also interface functions which can process these raw messages to
+extract variables and fields for the model ``inputs`` and ``outputs`` to
+specify how that should be done. For examples of how to use formatted messages
+with the above file types and input/output options, see
 :ref:`Formatted I/O <formatted_io_rst>`.
 
-	  
+
 Model-to-model communication (with connections)
 -----------------------------------------------
 
-Models can also communicate with each other in the same fashion. In the example 
+Models can also communicate with each other in the same fashion. In the example
 below, model A receives input from a channel named 'inputA' and sends output to
 a channel named 'outputA', while model B receives input from a channel named
 'inputB' and sends output to a channel named 'outputB'.
 
 .. include:: examples/gs_lesson4_src.rst
 
-In the YAML, 'inputA' is connected to a local file, 'outputA' is connected to 
-'inputB', and 'outputB' is connected to a local file in the ``connections`` 
+In the YAML, 'inputA' is connected to a local file, 'outputA' is connected to
+'inputB', and 'outputB' is connected to a local file in the ``connections``
 section of the YAML.
 
 .. include:: examples/gs_lesson4_yml.rst
@@ -128,14 +145,14 @@ section of the YAML.
 Model-to-model communication (with drivers)
 -------------------------------------------
 
-For backwards compatibility, connections can also be specified in terms of 
-the underlying drivers without an explicit ``connections`` section. The 
-exact same models from the previous example can be connected using the 
+For backwards compatibility, connections can also be specified in terms of
+the underlying drivers without an explicit ``connections`` section. The
+exact same models from the previous example can be connected using the
 following YAML.
 
 .. include:: examples/gs_lesson4b_yml.rst
 
-In this schema, model ``input`` and ``output`` entries 
+In this schema, model ``input`` and ``output`` entries
 must have the following fields:
 
 ======    ======================================================================
@@ -144,7 +161,7 @@ Field     Description
 name      The name of the channel that will be used by the model.
 driver    The name of the driver that should be used to process input/output.
 args      A string matching the args field of an opposing ``input`` /
-          ``output`` field in another model or the path to a file that should 
+          ``output`` field in another model or the path to a file that should
           be read/written.
 ======    ======================================================================
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ requirements:
     - sysv_ipc  # [unix]
     - unyt  # [not py2k]
     - zeromq
+    - GitPython
 
 test:
   imports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ scipy
 six
 sysv_ipc; platform_system != 'Windows'
 unyt; python_version >= '3.4'
+GitPython

--- a/requirements_condaonly.txt
+++ b/requirements_condaonly.txt
@@ -4,4 +4,3 @@ r-base
 r-reticulate
 r-zeallot
 zeromq
-GitPython

--- a/requirements_condaonly.txt
+++ b/requirements_condaonly.txt
@@ -4,3 +4,4 @@ r-base
 r-reticulate
 r-zeallot
 zeromq
+GitPython

--- a/yggdrasil/tests/test_yamlfile.py
+++ b/yggdrasil/tests/test_yamlfile.py
@@ -118,7 +118,7 @@ class YamlTestBase(YggTestClass):
 
     def test_load_yaml_git(self):
         yml = "https://github.com/cropsinsilico/example-fakemodel/fakemodel.yml"
-        self.assertRaises(OSError, yamlfile.load_yaml, yml)
+        self.assertRaises(Exception, yamlfile.load_yaml, yml)
         self.assertTrue('model' in yamlfile.load_yaml('git:' + yml))
 
 

--- a/yggdrasil/tests/test_yamlfile.py
+++ b/yggdrasil/tests/test_yamlfile.py
@@ -120,6 +120,8 @@ class YamlTestBase(YggTestClass):
         yml = "https://github.com/cropsinsilico/example-fakemodel/fakemodel.yml"
         self.assertRaises(Exception, yamlfile.load_yaml, yml)
         self.assertTrue('model' in yamlfile.load_yaml('git:' + yml))
+        yml = "cropsinsilico/example-fakemodel/fakemodel.yml"
+        self.assertTrue('model' in yamlfile.load_yaml('git:' + yml))
 
 
 class YamlTestBaseError(YamlTestBase):

--- a/yggdrasil/tests/test_yamlfile.py
+++ b/yggdrasil/tests/test_yamlfile.py
@@ -41,7 +41,7 @@ def test_load_yaml():
         # Remove file
         if os.path.isfile(fname):
             os.remove(fname)
-            
+
 
 def test_load_yaml_error():
     r"""Test error on loading invalid file."""
@@ -115,6 +115,11 @@ class YamlTestBase(YggTestClass):
             yamlfile.parse_yaml(self.files[0])
         else:
             yamlfile.parse_yaml(self.files)
+
+    def test_load_yaml_git(self):
+        yml = "https://github.com/cropsinsilico/example-fakemodel/fakemodel.yml"
+        self.assertRaises(OSError, yamlfile.load_yaml, yml)
+        self.assertTrue('model' in yamlfile.load_yaml('git:' + yml))
 
 
 class YamlTestBaseError(YamlTestBase):

--- a/yggdrasil/yamlfile.py
+++ b/yggdrasil/yamlfile.py
@@ -23,10 +23,10 @@ def load_yaml(fname):
             to a file containing a YAML, or a loaded YAML document. If fname starts with
             'git:' then the code will assume the file is in a remote git repository. The
             remainder of fname can be the full url to the YAML file
-            (http://mygit.repo/foo/bar/yaml/interesting.yaml) or just the repo and
+            (http://mygit.repo/foo/bar/yaml/interesting.yml) or just the repo and
             YAML file (the server is assumed to be github.com if not given)
             (foo/bar/yam/interesting.yaml will be interpreted as
-            http://github.com/foo/bar/yam/interesting.yaml).
+            http://github.com/foo/bar/yam/interesting.yml).
 
     Returns:
         dict: Contents of yaml file.

--- a/yggdrasil/yamlfile.py
+++ b/yggdrasil/yamlfile.py
@@ -14,6 +14,7 @@ if sys.version_info > (3, 0):
 else:
     from urlparse import urlparse
 
+
 def load_yaml(fname):
     r"""Parse a yaml file defining a run.
 
@@ -21,9 +22,11 @@ def load_yaml(fname):
         fname (str, file, dict): Path to a YAML file, an open file descriptor
             to a file containing a YAML, or a loaded YAML document. If fname starts with
             'git:' then the code will assume the file is in a remote git repository. The
-            remainder of fname can be the full url to the YAML file (http://mygit.repo/foo/bar/yaml/interesting.yaml)
-            or just the repo and YAML file (the server is assumed to be github.com if not given)
-            (foo/bar/yam/interesting.yaml will be interpreted as http://github.com/foo/bar/yam/interesting.yaml).
+            remainder of fname can be the full url to the YAML file
+            (http://mygit.repo/foo/bar/yaml/interesting.yaml) or just the repo and
+            YAML file (the server is assumed to be github.com if not given)
+            (foo/bar/yam/interesting.yaml will be interpreted as
+            http://github.com/foo/bar/yam/interesting.yaml).
 
     Returns:
         dict: Contents of yaml file.
@@ -58,9 +61,10 @@ def load_yaml(fname):
             # check to see if the file already exists, and clone if it does not
             if not os.path.exists(fname):
                 # create the url for cloning the repo
-                cloneurl = parsed.scheme + '://' + parsed.netloc + '/' + owner + '/' + reponame
+                cloneurl = parsed.scheme + '://' + parsed.netloc + '/' + owner + '/' +\
+                    reponame
                 # clone the repo into the appropriate directory
-                repo = git.Repo.clone_from(cloneurl, os.path.join(owner, reponame))
+                _ = git.Repo.clone_from(cloneurl, os.path.join(owner, reponame))
                 # now that it is cloned, just pass the yaml file (and path) onwards
         fname = os.path.realpath(fname)
         if not os.path.isfile(fname):

--- a/yggdrasil/yamlfile.py
+++ b/yggdrasil/yamlfile.py
@@ -22,7 +22,7 @@ def load_yaml(fname):
             to a file containing a YAML, or a loaded YAML document. If fname starts with
             'git:' then the code will assume the file is in a remote git repository. The
             remainder of fname can be the full url to the YAML file (http://mygit.repo/foo/bar/yaml/interesting.yaml)
-            or just the repo and YAML file (the server is assumed to be github.com if not given) 
+            or just the repo and YAML file (the server is assumed to be github.com if not given)
             (foo/bar/yam/interesting.yaml will be interpreted as http://github.com/foo/bar/yam/interesting.yaml).
 
     Returns:
@@ -55,11 +55,13 @@ def load_yaml(fname):
             # the full path is the file name and location
             # turn the file path into an os based format
             fname = os.path.join(*splitpath)
-            # create the url for cloning the repo
-            cloneurl = parsed.scheme + '://' + parsed.netloc + '/' + owner + '/' + reponame
-            # clone the repo into the appropriate directory
-            repo = git.Repo.clone_from(cloneurl, os.path.join(owner, reponame))
-            # now that it is cloned, just pass the yaml file (and path) onwards
+            # check to see if the file already exists, and clone if it does not
+            if not os.path.exists(fname):
+                # create the url for cloning the repo
+                cloneurl = parsed.scheme + '://' + parsed.netloc + '/' + owner + '/' + reponame
+                # clone the repo into the appropriate directory
+                repo = git.Repo.clone_from(cloneurl, os.path.join(owner, reponame))
+                # now that it is cloned, just pass the yaml file (and path) onwards
         fname = os.path.realpath(fname)
         if not os.path.isfile(fname):
             raise IOError("Unable locate yaml file %s" % fname)
@@ -259,8 +261,8 @@ def parse_model(yml, existing):
             x['model_driver'] = [yml['name']]
             existing = parse_component(x, io[:-1], existing=existing)
     return existing
-            
-    
+
+
 def parse_connection(yml, existing):
     r"""Parse a yaml entry for a connection between I/O channels.
 
@@ -367,7 +369,7 @@ def parse_connection(yml, existing):
         xi['driver'] = 'InputDriver'
 
     # Parse drivers
-    
+
     # Transfer connection keywords to one connection driver
     conn_keys_gen = ['inputs', 'outputs']
     conn_keys = list(set(schema['connection'].properties) - set(conn_keys_gen))


### PR DESCRIPTION
Code has been added to yamlfile.py to allow users to get YAML files from remote repositories. the filename just needs the 'git:' prefix to indicate that it is remote. The file name can be specified as a full url to the YAML file (e.g. git:http://github.com/foo/bar/yaml/interesting.yaml) or just as the repo + filename path (e.g. git:foo/bar/yaml/interesting.yaml). Both of these examples will get the same file. The code will clone the repo and then pass the YAML file (path and file name) to the rest of the code for processing. The code currently assumes that no credentials are needed to clone. An additional step that could be added is to check that the YAML has not already been cloned.