### PR TITLE
Matlab env variable issue on some OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -198,7 +198,7 @@ jobs:
           - $HOME/Library/Caches/pip
           - $HOME/Library/Caches/Homebrew
           - $HOME/R/Library
-      env: YGG_PYTHON=3.6 R_LIBS_USER=$HOME/R/Library YGG_TEST_FLAGS="tests/test_tools.py --test-suite=types --test-suite=timing --languages R c" INSTALLR=0
+      env: YGG_PYTHON=3.6 R_LIBS_USER=$HOME/R/Library YGG_TEST_FLAGS="tests/test_tools.py --test-suite=types --languages R c" INSTALLR=0
     - os: osx
       python: 3.7
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
@@ -207,7 +207,7 @@ jobs:
         directories:
           - $HOME/Library/Caches/pip
           - $HOME/Library/Caches/Homebrew
-      env: YGG_CONDA=3.7 YGG_TEST_FLAGS="serialize --test-suite=examples_part1 communication/tests/test_IPCComm.py communication/tests/test_RMQAsyncComm.py" INSTALLZMQ=0
+      env: YGG_CONDA=3.7 YGG_TEST_FLAGS="serialize --test-suite=examples_part1 communication/tests/test_IPCComm.py communication/tests/test_RMQAsyncComm.py --test-suite=timing" INSTALLZMQ=0
       script:
         - yggconfig --remove-file
         - yggtest --ci tests/test_config.py $YGG_TEST_FLAGS

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - cmake
     - czmq
     - flaky
+    - git
     - GitPython
     - jsonschema
     - matplotlib-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "yggdrasil" %}
-{% set version = "0.10.0" %}
+{% set version = "1.1.1" %}
 
 package:
   name: {{ name|lower }}
@@ -9,9 +9,9 @@ source:
   path: ../
 
 build:
-  number: 1
+  number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
-  skip: true  # [win and vc<14]
+  skip: true  # [(win and vc<14) or py<35]
   entry_points:
     - ygginfo = yggdrasil.command_line:ygginfo
     - yggrun = yggdrasil.command_line:yggrun
@@ -33,9 +33,6 @@ build:
     - ygginstall = yggdrasil.command_line:ygginstall
 
 requirements:
-  # build:
-  #   - {{ compiler('c') }}
-  #   - {{ compiler('cxx') }}
   host:
     - czmq
     - pip
@@ -48,7 +45,7 @@ requirements:
     - flaky
     - GitPython
     - jsonschema
-    - matplotlib
+    - matplotlib-base
     - numpy
     - pandas
     - pyperf

--- a/yggdrasil/drivers/MatlabModelDriver.py
+++ b/yggdrasil/drivers/MatlabModelDriver.py
@@ -601,7 +601,7 @@ class MatlabModelDriver(InterpretedModelDriver):  # pragma: matlab
         if matlab_engine is None:
             lines.append("exit(0);")
         # Write lines
-        logger.info('Wrapper:\n\t%s', '\n\t'.join(lines))
+        logger.debug('Wrapper:\n\t%s', '\n\t'.join(lines))
         if fname is None:
             return lines
         else:

--- a/yggdrasil/examples/gs_lesson3/src/gs_lesson3.m
+++ b/yggdrasil/examples/gs_lesson3/src/gs_lesson3.m
@@ -1,36 +1,29 @@
 % Initialize input/output channels
+in_channel = YggInterface('YggInput', 'input');
+out_channel = YggInterface('YggOutput', 'output');
 
-disp('matlab_model:input_IN')
-disp(getenv('matlab_model:input_IN'))
-disp('matlab_model:output_OUT')
-disp(getenv('matlab_model:output_OUT'))
+flag = true;
+
+% Loop until there is no longer input or the queues are closed
+while flag
+
+  % Receive input from input channel 
+  % If there is an error, the flag will be False.
+  [flag, msg] = in_channel.recv();
+  if (~flag)
+    disp('No more input.');
+    break
+  end
+
+  % Print received message
+  fprintf('%s\n', char(msg));
+
+  % Send output to output channel
+  % If there is an error, the flag will be False
+  flag = out_channel.send(msg);
+  if (~flag)
+    disp('Error sending output.');
+    break
+  end
   
-
-% in_channel = YggInterface('YggInput', 'input');
-% out_channel = YggInterface('YggOutput', 'output');
-
-% flag = true;
-
-% % Loop until there is no longer input or the queues are closed
-% while flag
-
-%   % Receive input from input channel 
-%   % If there is an error, the flag will be False.
-%   [flag, msg] = in_channel.recv();
-%   if (~flag)
-%     disp('No more input.');
-%     break
-%   end
-
-%   % Print received message
-%   fprintf('%s\n', char(msg));
-
-%   % Send output to output channel
-%   % If there is an error, the flag will be False
-%   flag = out_channel.send(msg);
-%   if (~flag)
-%     disp('Error sending output.');
-%     break
-%   end
-  
-% end
+end

--- a/yggdrasil/examples/gs_lesson3/src/gs_lesson3.m
+++ b/yggdrasil/examples/gs_lesson3/src/gs_lesson3.m
@@ -1,6 +1,8 @@
 % Initialize input/output channels
 
+disp('matlab_model:input_IN')
 disp(getenv('matlab_model:input_IN'))
+disp('matlab_model:output_OUT')
 disp(getenv('matlab_model:output_OUT'))
   
 

--- a/yggdrasil/examples/gs_lesson3/src/gs_lesson3.m
+++ b/yggdrasil/examples/gs_lesson3/src/gs_lesson3.m
@@ -1,29 +1,34 @@
-% Initialize input/output channels 
-in_channel = YggInterface('YggInput', 'input');
-out_channel = YggInterface('YggOutput', 'output');
+% Initialize input/output channels
 
-flag = true;
-
-% Loop until there is no longer input or the queues are closed
-while flag
-
-  % Receive input from input channel 
-  % If there is an error, the flag will be False.
-  [flag, msg] = in_channel.recv();
-  if (~flag)
-    disp('No more input.');
-    break
-  end
-
-  % Print received message
-  fprintf('%s\n', char(msg));
-
-  % Send output to output channel
-  % If there is an error, the flag will be False
-  flag = out_channel.send(msg);
-  if (~flag)
-    disp('Error sending output.');
-    break
-  end
+disp(getenv('matlab_model:input_IN'))
+disp(getenv('matlab_model:output_OUT'))
   
-end
+
+% in_channel = YggInterface('YggInput', 'input');
+% out_channel = YggInterface('YggOutput', 'output');
+
+% flag = true;
+
+% % Loop until there is no longer input or the queues are closed
+% while flag
+
+%   % Receive input from input channel 
+%   % If there is an error, the flag will be False.
+%   [flag, msg] = in_channel.recv();
+%   if (~flag)
+%     disp('No more input.');
+%     break
+%   end
+
+%   % Print received message
+%   fprintf('%s\n', char(msg));
+
+%   % Send output to output channel
+%   % If there is an error, the flag will be False
+%   flag = out_channel.send(msg);
+%   if (~flag)
+%     disp('Error sending output.');
+%     break
+%   end
+  
+% end

--- a/yggdrasil/languages/R/DESCRIPTION
+++ b/yggdrasil/languages/R/DESCRIPTION
@@ -10,7 +10,7 @@ LazyData: true
 Imports:
     bit64,
     reticulate,
-    units,
+    units (<= 0.6-5),
     zeallot,
     R6
 Depends:

--- a/yggdrasil/languages/R/DESCRIPTION
+++ b/yggdrasil/languages/R/DESCRIPTION
@@ -10,7 +10,7 @@ LazyData: true
 Imports:
     bit64,
     reticulate,
-    units (<= 0.6-5),
+    units,
     zeallot,
     R6
 Depends:


### PR DESCRIPTION
This fixes a bug where on some operating systems, the environment variables in the process used to launch Matlab are not inherited by the Matlab script.